### PR TITLE
Make challenge pages display identically and default to Hebrew

### DIFF
--- a/client/src/pages/challenge.tsx
+++ b/client/src/pages/challenge.tsx
@@ -1,19 +1,13 @@
 import { useState } from "react";
 import { useRoute, useLocation } from "wouter";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronLeft, Sparkles, Calendar } from "lucide-react";
+import { ChevronLeft, Sparkles } from "lucide-react";
 import { formatTextContent } from "@/lib/text-formatter";
 import { FloatingSettings } from "@/components/ui/floating-settings";
 import type { TodaysSpecial } from "@shared/schema";
 
 type ChallengeWithExpiry = TodaysSpecial & { isExpired: boolean };
 
-const formatDateRange = (from: string, until: string) => {
-  const opts: Intl.DateTimeFormatOptions = { month: "long", day: "numeric", year: "numeric" };
-  const f = new Date(from + "T00:00:00").toLocaleDateString("en-US", opts);
-  const u = new Date(until + "T00:00:00").toLocaleDateString("en-US", opts);
-  return from === until ? f : `${f} – ${u}`;
-};
 
 export default function ChallengePage() {
   const [, params] = useRoute("/challenge/:id");
@@ -21,7 +15,7 @@ export default function ChallengePage() {
   const id = params?.id || "";
 
   const [fontSize, setFontSize] = useState(16);
-  const [language, setLanguage] = useState<"hebrew" | "english">("english");
+  const [language, setLanguage] = useState<"hebrew" | "english">("hebrew");
 
   const { data: challenge, isLoading, error } = useQuery<ChallengeWithExpiry>({
     queryKey: ["/api/challenge", id],
@@ -116,14 +110,8 @@ export default function ChallengePage() {
             </div>
             <p className="platypi-bold text-lg text-black leading-snug">{challenge.title}</p>
             {challenge.subtitle && (
-              <p className="platypi-regular text-sm text-black/70">{challenge.subtitle}</p>
+              <p className={`text-sm text-black/70 ${/[\u0590-\u05FF]/.test(challenge.subtitle) ? 'vc-koren-hebrew' : 'platypi-regular'}`}>{challenge.subtitle}</p>
             )}
-            <div className="flex items-center gap-1.5 pt-1">
-              <Calendar size={12} className="text-black/40" />
-              <p className="platypi-regular text-xs text-black/40">
-                {formatDateRange(challenge.fromDate, challenge.untilDate)}
-              </p>
-            </div>
           </div>
 
           {challenge.isExpired && (


### PR DESCRIPTION
Update challenge page to remove date display, set default language to Hebrew, and ensure Hebrew subtitles use the correct font.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: d421d7c2-fa29-4627-8fc4-8567027664d7
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: c243408c-0f73-441d-a89f-35a847f97118
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/ea367e04-e505-47ab-af76-4df2facf13dc/d421d7c2-fa29-4627-8fc4-8567027664d7/BhTRyNF